### PR TITLE
changed zIndex so that blocknote UI is above

### DIFF
--- a/app/(main)/_components/Navigation.tsx
+++ b/app/(main)/_components/Navigation.tsx
@@ -144,7 +144,7 @@ function Navigation() {
       <aside
         ref={sidebarRef}
         className={cn(
-          "group/sidebar relative z-[99999] flex h-full w-60 flex-col overflow-y-auto bg-secondary",
+          "group/sidebar relative z-[250] flex h-full w-60 flex-col overflow-y-auto bg-secondary",
           isResetting && "transition-all duration-300 ease-in-out",
           isMobile && "w-0",
         )}


### PR DESCRIPTION
Fixes #1 
#changed Z index of sidebar

BlockNote UI have z index of 300 and here "aside" had 99999 that is why the blocknote menu component was below the side bar. I have changed the z index to 250.
![Screenshot 2024-07-26 185557](https://github.com/user-attachments/assets/92bbd9f6-cfb2-4726-9a59-ad9b492282b7)
